### PR TITLE
feat/Now handles if a user drops zip file(s) in the Plugins directory. 

### DIFF
--- a/GameHelper/Plugin/PManager.cs
+++ b/GameHelper/Plugin/PManager.cs
@@ -11,6 +11,7 @@ namespace GameHelper.Plugin
     using System.Reflection;
     using System.Threading.Tasks;
     using System.IO.Compression; // added for zip extraction
+    using System.Diagnostics;    // added for dotnet build
     using Coroutine;
     using CoroutineEvents;
     using CTOUtils = ClickableTransparentOverlay.Win32.Utils;
@@ -43,6 +44,9 @@ namespace GameHelper.Plugin
             // Expand any .zip files dropped in the Plugins folder before scanning directories.
             ExtractZipPluginsIfAny();
 
+            // NEW: Build existing plugin folders that have a project/solution but no top-level dll matching the folder name.
+            EnsureBuiltPluginsInPlace();
+
             LoadPluginMetadata(LoadPlugins());
 #if DEBUG
             GetAllPluginNames();
@@ -57,9 +61,9 @@ namespace GameHelper.Plugin
         /// <summary>
         /// Extract any non-hidden *.zip files in the Plugins directory.
         /// Destination folder name is taken from the plugin DLL file name (without extension).
-        /// If the ZIP already contains a single top-level folder, we avoid nesting by moving that folder.
-        /// Ensures the DLL exists at the destination folder root so ReadPluginFiles can find it.
-        /// Deletes the ZIP after a successful extraction.
+        /// - If the ZIP already contains a single top-level folder, avoid nesting by moving that folder.
+        /// - Prefer/builder produces a DLL; ensure a DLL exists at root of final folder.
+        /// - Delete the ZIP after a successful extraction.
         /// </summary>
         private static void ExtractZipPluginsIfAny()
         {
@@ -88,38 +92,23 @@ namespace GameHelper.Plugin
                         // If there is exactly one top-level folder and no top-level files, use that as content root
                         var contentRoot = (topFiles.Length == 0 && topDirs.Length == 1) ? topDirs[0] : tempDir;
 
-                        // Find the plugin dll anywhere under the content root
-                        var dllPath = Directory
-                            .EnumerateFiles(contentRoot, "*.dll", SearchOption.AllDirectories)
-                            .FirstOrDefault();
+                        // Try to build if project/solution exists; else pick an existing DLL similar to zip base name
+                        string targetName = Path.GetFileNameWithoutExtension(zip.Name);
+                        string builtDllPath = TryBuildIfProject(contentRoot, targetName);
+                        string dllPath = builtDllPath ?? PickDllBySimilarity(contentRoot, targetName);
 
                         if (dllPath == null)
                         {
-                            Console.WriteLine($"[PManager] No dll found in '{zip.Name}', skipping.");
+                            Console.WriteLine($"[PManager] No dll found or produced in '{zip.Name}', skipping.");
                             Directory.Delete(tempDir, true);
                             continue;
                         }
 
-                        // Ensure the DLL is present at the root of the contentRoot (so after move, it is at finalDir root).
-                        // If it's nested, copy it up to the contentRoot.
-                        var dllRel = Path.GetRelativePath(contentRoot, dllPath);
-                        var dllRelDir = Path.GetDirectoryName(dllRel);
-                        if (!string.IsNullOrEmpty(dllRelDir))
-                        {
-                            var dllAtRoot = Path.Combine(contentRoot, Path.GetFileName(dllPath));
-                            try
-                            {
-                                File.Copy(dllPath, dllAtRoot, overwrite: true);
-                                dllPath = dllAtRoot; // update reference to the top-level copy
-                            }
-                            catch (Exception copyEx)
-                            {
-                                Console.WriteLine($"[PManager] Failed to copy DLL to root for '{zip.Name}': {copyEx}");
-                            }
-                        }
+                        // Ensure the DLL is present at the root of the contentRoot
+                        var dllAtRoot = EnsureDllAtRoot(contentRoot, dllPath);
 
-                        // Final folder name comes from the dll's file name (minus extension)
-                        var dllBaseName = Path.GetFileNameWithoutExtension(dllPath);
+                        // Final folder name comes from the dll's base name
+                        var dllBaseName = Path.GetFileNameWithoutExtension(dllAtRoot);
                         var finalDir = Path.Combine(State.PluginsDirectory.FullName, dllBaseName);
 
                         // If the destination already exists, remove it to avoid nesting/merge issues
@@ -139,8 +128,6 @@ namespace GameHelper.Plugin
                         }
 
                         // Move the content root into place:
-                        //   - If contentRoot == tempDir, this is the whole extracted set (no single root folder)
-                        //   - If contentRoot is the single root folder, move just that folder (prevents extra nesting)
                         if (string.Equals(contentRoot, tempDir, StringComparison.OrdinalIgnoreCase))
                         {
                             Directory.Move(tempDir, finalDir);
@@ -154,6 +141,9 @@ namespace GameHelper.Plugin
                                 Directory.Delete(tempDir, true);
                             }
                         }
+
+                        // Ensure we have a DLL named exactly as the folder (e.g., {Folder}.dll)
+                        EnsureDllNamedAfterFolder(finalDir);
 
                         // Remove the zip after successful extraction/placement
                         zip.Delete();
@@ -179,6 +169,288 @@ namespace GameHelper.Plugin
             catch (Exception ex)
             {
                 Console.WriteLine($"[PManager] ZIP scan failed: {ex}");
+            }
+        }
+
+        /// <summary>
+        /// NEW: For each plugin directory, if there is no top-level DLL matching the folder name,
+        /// but a .csproj or .sln exists in the tree, compile and place the resulting DLL at the root.
+        /// Also ensure a DLL exists named exactly {Folder}.dll (copy/rename as needed).
+        /// </summary>
+        private static void EnsureBuiltPluginsInPlace()
+        {
+            try
+            {
+                var dirs = GetPluginsDirectories();
+                foreach (var dir in dirs)
+                {
+                    try
+                    {
+                        // Do we already have a DLL at top level that matches the loader pattern?
+                        var topDll = dir.GetFiles($"{dir.Name}*.dll", SearchOption.TopDirectoryOnly).FirstOrDefault();
+                        if (topDll != null)
+                        {
+                            // Optionally enforce exact name {Folder}.dll for consistency
+                            EnsureDllNamedAfterFolder(dir.FullName);
+                            continue;
+                        }
+
+                        // If no matching dll, but has a project/solution, try to build.
+                        var hasProjOrSln =
+                            Directory.EnumerateFiles(dir.FullName, "*.csproj", SearchOption.AllDirectories).Any() ||
+                            Directory.EnumerateFiles(dir.FullName, "*.sln", SearchOption.AllDirectories).Any();
+
+                        if (!hasProjOrSln)
+                        {
+                            continue;
+                        }
+
+                        Console.WriteLine($"[PManager] Building plugin folder '{dir.Name}' due to missing top-level dll.");
+                        var builtDll = TryBuildIfProject(dir.FullName, dir.Name);
+                        if (builtDll == null)
+                        {
+                            Console.WriteLine($"[PManager] Build did not produce a DLL for '{dir.Name}'.");
+                            continue;
+                        }
+
+                        // Ensure the built DLL is at root
+                        var dllAtRoot = EnsureDllAtRoot(dir.FullName, builtDll);
+
+                        // Ensure we have a DLL named exactly as the folder
+                        EnsureDllNamedAfterFolder(dir.FullName);
+
+                        Console.WriteLine($"[PManager] Built and prepared plugin '{dir.Name}'.");
+                    }
+                    catch (Exception exInner)
+                    {
+                        Console.WriteLine($"[PManager] EnsureBuiltPluginsInPlace error for '{dir.FullName}': {exInner}");
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[PManager] EnsureBuiltPluginsInPlace failed: {ex}");
+            }
+        }
+
+        /// <summary>
+        /// If a .csproj or .sln exists in contentRoot, attempts to build it with `dotnet build -c Release`.
+        /// On success, returns the path to the produced DLL (favoring names similar to targetName, else newest).
+        /// Returns null on failure or if no project/solution exists.
+        /// </summary>
+        private static string TryBuildIfProject(string contentRoot, string targetName)
+        {
+            try
+            {
+                var csprojs = Directory.GetFiles(contentRoot, "*.csproj", SearchOption.AllDirectories);
+                var slns = Directory.GetFiles(contentRoot, "*.sln", SearchOption.AllDirectories);
+
+                if (csprojs.Length == 0 && slns.Length == 0)
+                {
+                    return null;
+                }
+
+                // Prefer building a csproj that best matches the targetName; otherwise first one.
+                string projToBuild = csprojs
+                    .OrderBy(p => SimilarityScore(Path.GetFileNameWithoutExtension(p), targetName))
+                    .FirstOrDefault();
+
+                bool isSolution = false;
+                if (projToBuild == null && slns.Length > 0)
+                {
+                    // If only a solution is present (or no good csproj match), build the solution.
+                    projToBuild = slns
+                        .OrderBy(s => SimilarityScore(Path.GetFileNameWithoutExtension(s), targetName))
+                        .First();
+                    isSolution = true;
+                }
+
+                if (projToBuild == null)
+                {
+                    return null;
+                }
+
+                var workDir = Path.GetDirectoryName(projToBuild) ?? contentRoot;
+                var args = $"build \"{projToBuild}\" -c Release -nologo";
+
+                Console.WriteLine($"[PManager] Building {(isSolution ? "solution" : "project")} '{projToBuild}'...");
+                var (exitCode, stdout, stderr) = RunProcess("dotnet", args, workDir);
+
+                if (exitCode != 0)
+                {
+                    Console.WriteLine($"[PManager] Build failed (exit {exitCode}).\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}");
+                    return null;
+                }
+
+                // Search for DLLs under bin/Release of the project (or of all projects if solution)
+                var searchRoots = isSolution
+                    ? Directory.GetDirectories(contentRoot, "*", SearchOption.AllDirectories)
+                    : new[] { Path.GetDirectoryName(projToBuild) ?? contentRoot };
+
+                var releaseDlls = searchRoots
+                    .SelectMany(r =>
+                    {
+                        var bins = Directory.GetDirectories(r, "bin", SearchOption.TopDirectoryOnly);
+                        return bins.SelectMany(b =>
+                        {
+                            var rel = Path.Combine(b, "Release");
+                            return Directory.Exists(rel)
+                                ? Directory.EnumerateFiles(rel, "*.dll", SearchOption.AllDirectories)
+                                : Array.Empty<string>();
+                        });
+                    })
+                    .Distinct()
+                    .ToList();
+
+                if (releaseDlls.Count == 0)
+                {
+                    Console.WriteLine($"[PManager] Build succeeded but produced no DLLs discoverable under bin/Release.");
+                    return null;
+                }
+
+                // Prefer DLL whose name matches targetName, else newest by write time
+                var picked = releaseDlls
+                    .OrderBy(p => SimilarityScore(Path.GetFileNameWithoutExtension(p), targetName))
+                    .ThenByDescending(p => GetSafeWriteTimeUtc(p))
+                    .First();
+
+                Console.WriteLine($"[PManager] Build produced '{picked}'.");
+                return picked;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[PManager] TryBuildIfProject error: {ex}");
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Ensure the specified dll is present at the root of contentRoot.
+        /// If nested, copies it up to contentRoot and returns that path.
+        /// </summary>
+        private static string EnsureDllAtRoot(string contentRoot, string dllPath)
+        {
+            try
+            {
+                var rel = Path.GetRelativePath(contentRoot, dllPath);
+                var relDir = Path.GetDirectoryName(rel);
+                if (string.IsNullOrEmpty(relDir) || relDir == "." || relDir == Path.DirectorySeparatorChar.ToString())
+                {
+                    return dllPath; // already at root
+                }
+
+                var rootCopy = Path.Combine(contentRoot, Path.GetFileName(dllPath));
+                File.Copy(dllPath, rootCopy, overwrite: true);
+                return rootCopy;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[PManager] Failed to ensure DLL at root: {ex}");
+                return dllPath;
+            }
+        }
+
+        /// <summary>
+        /// Ensure there is a DLL named exactly {FolderName}.dll at the folder's top level
+        /// (copy/rename from any top-level dll if necessary).
+        /// </summary>
+        private static void EnsureDllNamedAfterFolder(string folder)
+        {
+            try
+            {
+                var folderName = new DirectoryInfo(folder).Name;
+                var expected = Path.Combine(folder, folderName + ".dll");
+
+                if (File.Exists(expected))
+                    return;
+
+                // If a top-level dll exists, copy/rename it to {Folder}.dll
+                var anyTopDll = Directory.EnumerateFiles(folder, "*.dll", SearchOption.TopDirectoryOnly)
+                                         .FirstOrDefault();
+                if (anyTopDll != null)
+                {
+                    File.Copy(anyTopDll, expected, overwrite: true);
+                    return;
+                }
+
+                // Otherwise, try to find any dll anywhere and copy it to the top as {Folder}.dll
+                var anyDll = Directory.EnumerateFiles(folder, "*.dll", SearchOption.AllDirectories)
+                                      .FirstOrDefault();
+                if (anyDll != null)
+                {
+                    File.Copy(anyDll, expected, overwrite: true);
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[PManager] EnsureDllNamedAfterFolder error for '{folder}': {ex}");
+            }
+        }
+
+        /// <summary>
+        /// Pick a DLL inside contentRoot, favoring name similarity to a target (e.g., zip base name).
+        /// If none match, pick the newest by write time.
+        /// </summary>
+        private static string PickDllBySimilarity(string contentRoot, string targetBaseName)
+        {
+            var dlls = Directory.EnumerateFiles(contentRoot, "*.dll", SearchOption.AllDirectories).ToList();
+            if (dlls.Count == 0)
+            {
+                return null;
+            }
+
+            return dlls
+                .OrderBy(p => SimilarityScore(Path.GetFileNameWithoutExtension(p), targetBaseName))
+                .ThenByDescending(p => GetSafeWriteTimeUtc(p))
+                .First();
+        }
+
+        /// <summary>
+        /// Lower is better. 0 = exact (case-insensitive), 1 = startswith, 2 = contains, 3 = other.
+        /// </summary>
+        private static int SimilarityScore(string candidate, string target)
+        {
+            if (string.IsNullOrEmpty(candidate) || string.IsNullOrEmpty(target))
+                return 3;
+
+            var c = candidate.Trim();
+            var t = target.Trim();
+            if (c.Equals(t, StringComparison.OrdinalIgnoreCase)) return 0;
+            if (c.StartsWith(t, StringComparison.OrdinalIgnoreCase)) return 1;
+            if (c.IndexOf(t, StringComparison.OrdinalIgnoreCase) >= 0) return 2;
+            return 3;
+        }
+
+        private static DateTime GetSafeWriteTimeUtc(string path)
+        {
+            try { return File.GetLastWriteTimeUtc(path); } catch { return DateTime.MinValue; }
+        }
+
+        private static (int exitCode, string stdout, string stderr) RunProcess(string fileName, string arguments, string workingDirectory)
+        {
+            try
+            {
+                var psi = new ProcessStartInfo
+                {
+                    FileName = fileName,
+                    Arguments = arguments,
+                    WorkingDirectory = workingDirectory,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                };
+
+                using var proc = new Process { StartInfo = psi };
+                proc.Start();
+                var stdout = proc.StandardOutput.ReadToEnd();
+                var stderr = proc.StandardError.ReadToEnd();
+                proc.WaitForExit();
+                return (proc.ExitCode, stdout, stderr);
+            }
+            catch (Exception ex)
+            {
+                return (-1, "", $"Process start failed: {ex}");
             }
         }
 

--- a/GameHelper/Settings/SettingsWindow.cs
+++ b/GameHelper/Settings/SettingsWindow.cs
@@ -582,6 +582,9 @@ namespace GameHelper.Settings
                     }
                 }
 
+                ImGui.Checkbox("Always rebuild plugin projects on startup", ref Core.GHSettings.AlwaysRebuildPlugins);
+                ImGuiHelper.ToolTip("If enabled, on startup GameHelper will rebuild all .sln/.csproj found under each plugin folder and place the resulting DLL at the folder root (named {Folder}.dll).");
+
                 ImGui.Checkbox("Is Taiwan client", ref Core.GHSettings.IsTaiwanClient);
             }
         }

--- a/GameHelper/Settings/State.cs
+++ b/GameHelper/Settings/State.cs
@@ -220,6 +220,11 @@ namespace GameHelper.Settings
         public bool ProcessAllRenderableEntities = false;
 
         /// <summary>
+        ///    Gets or sets a value indicating whether user wants to always rebuild projects found in Plugins folder.
+        /// </summary>
+        public bool AlwaysRebuildPlugins = false;
+
+        /// <summary>
         ///     Gets a value indicating if user is running Taiwan client or not.
         /// </summary>
         public bool IsTaiwanClient = false;


### PR DESCRIPTION
If a user doesn't extract from the zip, current state - the plugin won't load. This change allows Gamehelper to extract and correctly place the files in the Plugins directory, then will load these extracted files in the normal flow. Tested with Atlas and AuraTracker plugin zips being dropped into the Plugins directory. Atlas has files in the root of the zip, while Aura Tracker has them within a folder in the root of the zip. This handles both scenarios correctly.